### PR TITLE
Add hardware-free host test framework (Google Test + CMake)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,33 @@
+name: Host Tests
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  test:
+    name: Build & run tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Cache the CMake build directory so FetchContent downloads
+      # (GoogleTest, ArduinoJson) are reused across runs.
+      - name: Cache CMake build
+        uses: actions/cache@v4
+        with:
+          path: tests/build
+          key: cmake-${{ runner.os }}-${{ hashFiles('tests/CMakeLists.txt') }}
+          restore-keys: cmake-${{ runner.os }}-
+
+      - name: Configure
+        run: cmake -S tests -B tests/build -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build tests/build --parallel
+
+      - name: Test
+        run: ctest --test-dir tests/build --output-on-failure


### PR DESCRIPTION
Introduces a native C++ test suite that runs on any Linux/macOS machine
without an ESP32, FastLED hardware, or WiFi connection.

Architecture
- tests/mocks/          — stub headers intercept all Arduino/ESP32 includes
  Arduino.h             — String class (ArduinoJson-compatible), millis(), Serial
  FastLED.h             — CRGB/CHSV with HSV→RGB, blend(), fill_solid(), CFastLED
  WiFi.h, HTTPClient.h  — injectable mock state (g_mock_http_code/payload)
  Preferences.h         — in-memory NVS backed by std::map
  WebServer.h           — injectable arg map + captured send/redirect values
  mock_support.cpp      — definitions for all extern globals

- tests/sketch_wrapper.cpp — compiles the .ino once into sketch_lib; mock
  headers shadow the real Arduino includes via the CMake include path

- tests/sketch_api.h — type/constant/extern declarations; test files include
  this instead of re-including the .ino (avoids multiple-definition ODR errors)

- tests/CMakeLists.txt — FetchContent pulls GoogleTest v1.14.0 and
  ArduinoJson v7.2.1 automatically; no manual installs needed

- tests/Makefile — `make` or `make test` wrapper for convenience

Test coverage (41 tests, all passing)
- test_temp_to_color.cpp  — hue mapping, clamping, monotonicity, custom range
- test_fetch_forecast.cpp — JSON parsing, HTTP errors, missing arrays, defaults
- test_poll_weather.cpp   — alert priority (rain > freeze > heat > none),
                            per-LED independence, failed-fetch fallback,
                            single FastLED.show() per poll, animation init
- test_animations.cpp     — hold-phase gating, fade-interval throttle,
                            blend direction reversal at 0/255, hold restart,
                            batched FastLED.show()

Sketch changes
- esp32-weather-leds.ino: wrap `#include "secrets.h"` with
  `#ifndef UNIT_TESTING` so host builds skip the gitignored file

https://claude.ai/code/session_01PQ5CXRW7wTNJabRWRKySU6