### PR TITLE
chore: version intermediate build artifacts and store uncompressed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,8 @@ jobs:
           MAJOR=$(grep '#define FW_VERSION_MAJOR' version.h | awk '{print $3}')
           MINOR=$(grep '#define FW_VERSION_MINOR' version.h | awk '{print $3}')
           PATCH=$(grep '#define FW_VERSION_PATCH' version.h | awk '{print $3}')
-          VERSION="${MAJOR}.${MINOR}.${PATCH}-dev"
+          TIMESTAMP=$(date -u +%Y%m%d-%H%M%S)
+          VERSION="${MAJOR}.${MINOR}.${PATCH}-dev-${TIMESTAMP}"
           echo "FW_VERSION=${VERSION}" >> $GITHUB_ENV
           cp build/esp32.esp32.d1_mini32/esp32-weather-leds.ino.bin \
              esp32-weather-leds-v${VERSION}.bin
@@ -57,7 +58,6 @@ jobs:
         with:
           name: esp32-weather-leds-v${{ env.FW_VERSION }}
           path: esp32-weather-leds-v${{ env.FW_VERSION }}.bin
-          compression-level: 0
 
   release:
     name: Publish release


### PR DESCRIPTION
Read FW_VERSION_MAJOR/MINOR/PATCH from version.h at build time,
rename the binary to esp32-weather-leds-v{VERSION}-dev.bin before
uploading, and use that as the artifact name. Sets compression-level: 0
so the binary is stored rather than additionally compressed.

Closes #24