### PR TITLE
feat: add emoji favicon and header icon to config UI

### DIFF
--- a/config_html.h
+++ b/config_html.h
@@ -5,6 +5,7 @@ const char CONFIG_HTML[] PROGMEM = R"rawhtml(
 <head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Weather LEDs Config</title>
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⛅</text></svg>">
 <style>
 body{font-family:sans-serif;max-width:500px;margin:2em auto;padding:0 1em;background:#1a1a1a;color:#e0e0e0}
 h1{font-size:1.3em}
@@ -22,7 +23,7 @@ select{width:100%%;box-sizing:border-box;background:#2a2a2a;color:#e0e0e0;border
 .locstatus{font-size:.8em;color:#aaa;margin-top:.4em;min-height:1.2em}
 </style>
 </head><body>
-<h1>Weather LEDs Config</h1>
+<h1>⛅ Weather LEDs Config</h1>
 <div style="display:%s;background:#1a2a3a;border:1px solid #2a5a8a;border-radius:4px;padding:.8em;margin-bottom:1em;color:#6aaddf">&#9432; Setup mode &mdash; connect to <strong>ESP32-Weather</strong>, then enter your WiFi credentials below and save.</div>
 <form method="POST" action="/save">
 <label>WiFi Network (SSID)</label>

--- a/esp32-weather-leds.ino
+++ b/esp32-weather-leds.ino
@@ -322,7 +322,7 @@ void startAPMode() {
 }
 
 void handleRoot() {
-  static char page[10240];
+  static char page[11264];
   String ip = g_ap_mode ? WiFi.softAPIP().toString() : WiFi.localIP().toString();
   snprintf(page, sizeof(page), CONFIG_HTML,
            g_ap_mode ? "block" : "none",

--- a/tests/test_handle_root.cpp
+++ b/tests/test_handle_root.cpp
@@ -114,6 +114,17 @@ TEST_F(HandleRootTest, InjectsFirmwareVersion) {
     EXPECT_NE(body.find(FIRMWARE_VERSION), std::string::npos);
 }
 
+// Description: The rendered page includes a favicon link tag so browsers
+// display a weather icon in tabs and bookmarks without any external fetch.
+TEST_F(HandleRootTest, ContainsFaviconEmoji) {
+    RecordProperty("description",
+        "The rendered page includes a favicon link tag so browsers display a "
+        "weather icon in tabs and bookmarks without any external fetch.");
+    handleRoot();
+    std::string body = g_mock_last_send_body.c_str();
+    EXPECT_NE(body.find("<link rel=\"icon\""), std::string::npos);
+}
+
 // Description: The build timestamp label appears in the rendered HTML alongside
 // the version string so the user can distinguish rebuilds of the same version number.
 // The exact timestamp value differs per translation unit so we check for the label.

--- a/version.h
+++ b/version.h
@@ -2,7 +2,7 @@
 #include <stdint.h>
 
 #define FW_VERSION_MAJOR 1
-#define FW_VERSION_MINOR 2
+#define FW_VERSION_MINOR 3
 #define FW_VERSION_PATCH 0
 
 #define FW_VERSION_INT \


### PR DESCRIPTION
Add a self-contained SVG emoji favicon (⛅) via a data URI in the HTML
<head>, and the same emoji in the <h1> heading. No external fetches or
filesystem images required — the icon lives entirely in CONFIG_HTML.

Grow the handleRoot() page buffer from 10 240 to 11 264 bytes to
accommodate the additional HTML and silence the -Wformat-truncation
compiler warning.

Closes #14

https://claude.ai/code/session_01Ue6C36VNysKR5SHKzbcAsM