### PR TITLE
docs: update README and CLAUDE.md for configurable LED count and AP SSID

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Required libraries: **FastLED** 3.10.3, **ArduinoJson** v7.x (v6 is incompatible
 
 WiFi credentials are configured at runtime — there is no `secrets.h`.
 On first boot (or whenever no credentials are saved in NVS), the device
-starts in AP mode: it broadcasts an open network named **ESP32-Weather**.
+starts in AP mode: it broadcasts an open network named **ESP32-WeatherLED**.
 Connect to that network, then visit `http://192.168.4.1/` to enter your
 SSID (use the Scan button) and password. After saving, the device reboots
 into normal station mode. Credentials persist in NVS across reboots.
@@ -35,10 +35,10 @@ Latitude/longitude are also set via the web UI.
 - `setup()` — loads config, initializes FastLED, connects WiFi (dim-orange on failure), starts `WebServer`, prints IP, clears LEDs
 - `loop()` — calls `server.handleClient()` every iteration; polls immediately on boot, then every `cfg_poll_min` minutes; `g_forceRepoll` flag triggers an out-of-schedule poll
 - `loadConfig()` / `saveConfig()` — reads/writes all runtime settings to NVS via `Preferences` (namespace `"wxleds"`)
-- `handleRoot()` — serves the HTML config page (`config_html.h`) with current config values injected via `snprintf`
-- `handleSave()` — processes POST from the config form, validates inputs, persists settings via `saveConfig()`, applies `FastLED.setBrightness()` immediately; sets `g_forceRepoll` if location changed
+- `handleRoot()` — serves the HTML config page (`config_html.h`) with current config values injected via `snprintf`; page adapts based on device mode: AP mode shows only WiFi fields, station mode shows full config
+- `handleSave()` — processes POST from the config form, validates inputs, persists settings via `saveConfig()`, applies `FastLED.setBrightness()` immediately; sets `g_forceRepoll` if location or `cfg_num_leds` changed; `cfg_num_leds` is clamped to 1–16
 - `handlePollNow()` — sets `g_forceRepoll = true`, triggering a poll on the next `loop()` iteration
-- `pollWeather()` — fetches all 6 days in one request, sets all LEDs, calls `FastLED.show()` once
+- `pollWeather()` — fetches `cfg_num_leds` days in one request, sets all LEDs, calls `FastLED.show()` once
 - `fetchForecast()` — HTTPS GET to Open-Meteo using `cfg_latitude`/`cfg_longitude`, filters JSON for max/min/precip arrays, computes daily averages
 - `tempToColor()` — maps °F to CHSV using runtime bounds: `cfg_cold_temp`→hue 160 (blue, default 20°F), `cfg_hot_temp`→hue 0 (red, default 90°F)
 
@@ -201,5 +201,5 @@ No manual upload is needed — pushing the tag is the complete release action.
 
 - **ArduinoJson v7 only.** Filter arrays with `filter["daily"]["temperature_2m_max"][0] = true` (the `[0]` is required to retain the whole array). Access via `.as<JsonArray>()`.
 - **Single `FastLED.show()` per poll cycle** — per-LED calls cause flicker.
-- **`forecast_days` equals `NUM_LEDS`** — changing LED count automatically adjusts the API request.
+- **`forecast_days` equals `cfg_num_leds`** — the runtime config value (not a compile-time constant) controls both the LED count and the number of forecast days requested from the API.
 - **`handleRoot()` page buffer is `static`** — the buffer must remain `static char page[...]` (currently 10 KB) to avoid a stack overflow in the WebServer callback. The ESP32 loop task stack is ~8 KB total; a plain local allocation of that size crashes the device. The `static` keyword is what matters; the buffer size may be grown as needed.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # ESP32 Weather LED Indicator
 
-Displays the next 6 days of average temperature forecast on 6 WS2812B LEDs.
+Displays up to 16 days of average temperature forecast on up to 16 WS2812B LEDs (configurable, default 6).
 Each LED represents one day, color-coded from blue (cold) to red (hot).
 
 ## Hardware
 
 - WeMos D1 Mini (ESP32)
-- 6x WS2812B addressable LEDs on GPIO 23 (GRB order, ensure load resistor on data is present or place your own)
+- 1–16x WS2812B addressable LEDs on GPIO 23 (default 6, configurable via web UI; GRB order, ensure load resistor on data is present or place your own)
 
 ## Color Scale
 
@@ -26,13 +26,14 @@ Bounds default to 20°F (cold/blue) and 90°F (hot/red) and are configurable via
 4. Set board `esp32:esp32:d1_mini32`
 5. Compile and flash (see CLAUDE.md) — no `secrets.h` needed
 6. On first boot the device starts in AP mode. Connect to the open Wi-Fi
-   network **ESP32-Weather** and visit `http://192.168.4.1/` to enter your
-   WiFi credentials (use the **Scan** button to see nearby networks). After
-   saving, the device reboots and connects normally.
+   network **ESP32-WeatherLED** and visit `http://192.168.4.1/` to enter your
+   WiFi credentials (use the **Scan** button to see nearby networks). The AP
+   mode page shows only WiFi fields; full config is available after connecting
+   to your network. After saving, the device reboots and connects normally.
 
 ## Configuration
 
-**First boot:** the device broadcasts an open AP named **ESP32-Weather**; connect and visit `http://192.168.4.1/` to set credentials. After saving, the device reboots into station mode and prints its IP to the serial monitor (`Web UI: http://<ip>/`). Visit that address to change any setting:
+**First boot:** the device broadcasts an open AP named **ESP32-WeatherLED**; connect and visit `http://192.168.4.1/` to set credentials. The AP mode page shows only WiFi fields; full config is available after connecting to your network. After saving, the device reboots into station mode and prints its IP to the serial monitor (`Web UI: http://<ip>/`). Visit that address to change any setting:
 
 | Setting | Default | Description |
 |---|---|---|
@@ -46,6 +47,7 @@ Bounds default to 20°F (cold/blue) and 90°F (hot/red) and are configurable via
 | Hot color bound | 90°F | Temperature mapped to red |
 | Latitude / Longitude | — | The page includes a ZIP code lookup that resolves to lat/lon in the browser (via zippopotam.us) — the ESP32 never makes this request |
 | Poll interval | 30 min | How often to fetch a new forecast |
+| Number of LEDs/days | 6 | Number of forecast days (1–16); LED 1 = today, LED N = N-1 days ahead |
 
 Settings are saved to flash (NVS) and persist across reboots. The "Poll Now" button forces an immediate weather fetch.
 


### PR DESCRIPTION
## Summary

- Replace hardcoded "6 days / 6 WS2812B" with "up to 16 (configurable, default 6)" in README intro, hardware section, and config table; add `num_leds` settings row
- Update AP network name `ESP32-Weather` → `ESP32-WeatherLED` throughout both files
- Note that AP mode shows only WiFi fields; full config is available after connecting to the network
- Update architecture notes in CLAUDE.md: `pollWeather` fetches `cfg_num_leds` days, `handleRoot` adapts by device mode, `handleSave` processes `cfg_num_leds` (clamped 1–16, triggers repoll if changed)
- Fix critical constraint: `cfg_num_leds` (runtime value) replaces stale `NUM_LEDS` (compile-time constant) reference

## Test plan

- [x] README renders correctly on GitHub — no stale "6 days", "6x WS2812B", or "ESP32-Weather" references
- [x] CLAUDE.md has no stale `NUM_LEDS` or "6 days" references in architecture/constraints sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)