### PR TITLE
Enhance README with detailed hardware setup and alert features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # ESP32 Weather LED Indicator
 
-Displays up to 16 days of average temperature forecast on up to 16 WS2812B LEDs (configurable, default 6).
-Each LED represents one day, color-coded from blue (cold) to red (hot).
+Displays up to 16 days of weather forecast on up to 16 WS2812B LEDs (default 6, configurable via web UI).
+Each LED represents one day, color-coded blue (cold) to red (hot). LEDs pulse to alert on freeze days
+(daily low ≤ 32°F), heat days (daily high ≥ 95°F), and rainy days (precipitation probability ≥ 50%) —
+all thresholds configurable.
 
 ## Hardware
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,14 @@ Each LED represents one day, color-coded from blue (cold) to red (hot).
 
 ## Hardware
 
-- WeMos D1 Mini (ESP32)
-- 1–16x WS2812B addressable LEDs on GPIO 23 (default 6, configurable via web UI; GRB order, ensure load resistor on data is present or place your own)
+![Assembled weather LED bar showing a rain-alert day](docs/demo.gif)
+
+### Components
+
+- **ESP32 controller** — [D1 Mini NodeMCU ESP32-WROOM-32](https://www.amazon.com/dp/B08L5XFWN6) (sold in 3-packs)
+- **LED strip** — [BTF-LIGHTING WS2812B ECO 100 LED/m, IP30](https://www.amazon.com/dp/B088B8G8LD) — cut to the number of LEDs you need (default 6, max 16); wired to GPIO 23 (GRB order, include a load resistor on the data line)
+- **LED channel/case** — [LED bar graph enclosure (MakerWorld, 3D-printable)](https://makerworld.com/en/models/2452077-led-bar-graph)
+- **D1 Mini case** — many options exist on MakerWorld/Printables; choice depends on your board variant and header configuration
 
 ## Color Scale
 


### PR DESCRIPTION
## Summary
Updated the README to provide clearer documentation of the project's capabilities and hardware requirements, including specific product recommendations and assembly guidance.

## Key Changes
- **Expanded feature description** — clarified that the project displays weather forecasts (not just temperature) with color-coded LEDs and added documentation of alert features: pulsing LEDs for freeze days (≤32°F), heat days (≥95°F), and rainy days (≥50% precipitation probability)
- **Added hardware demo image** — included an animated GIF showing the assembled weather LED bar in action
- **Detailed hardware section** — replaced generic component list with specific product recommendations including:
  - Direct Amazon links for ESP32 controller and WS2812B LED strip
  - Specific LED strip specifications (BTF-LIGHTING ECO 100 LED/m, IP30)
  - 3D-printable enclosure options (MakerWorld LED bar graph case)
  - Guidance on D1 Mini case selection
- **Clarified configuration** — emphasized that LED count (default 6, max 16) and all alert thresholds are configurable via web UI
- **Improved technical notes** — maintained important details about GPIO 23, GRB order, and load resistor requirements

## Notable Details
- All threshold values (freeze, heat, rain) are now documented as user-configurable
- Hardware recommendations are specific enough for users to source exact components while remaining flexible for alternatives

https://claude.ai/code/session_01Ts9Nw2pTzELhCH4NWjqxWa