### PR TITLE
chore: add AI-attribution line to all copyright notices

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
 Copyright (c) 2026 rojwilco
+AI-assisted: generated with Claude (Anthropic); human conception, review, guidance and output approval by rojwilco.
 
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007

--- a/config_html.h
+++ b/config_html.h
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 // Copyright (c) 2026 rojwilco
+// AI-assisted: generated with Claude (Anthropic); human conception, review, guidance and output approval by rojwilco.
 #pragma once
 
 const char CONFIG_HTML[] PROGMEM = R"rawhtml(

--- a/esp32-weather-leds.ino
+++ b/esp32-weather-leds.ino
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 // Copyright (c) 2026 rojwilco
+// AI-assisted: generated with Claude (Anthropic); human conception, review, guidance and output approval by rojwilco.
 #include <WiFi.h>
 #include <HTTPClient.h>
 #include <WiFiClientSecure.h>

--- a/tests/mocks/Arduino.h
+++ b/tests/mocks/Arduino.h
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (c) 2026 rojwilco
+// AI-assisted: generated with Claude (Anthropic); human conception, review, guidance and output approval by rojwilco.
 #pragma once
 
 #include <cstdint>

--- a/tests/mocks/FastLED.h
+++ b/tests/mocks/FastLED.h
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (c) 2026 rojwilco
+// AI-assisted: generated with Claude (Anthropic); human conception, review, guidance and output approval by rojwilco.
 #pragma once
 
 #include <cstdint>

--- a/tests/mocks/HTTPClient.h
+++ b/tests/mocks/HTTPClient.h
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (c) 2026 rojwilco
+// AI-assisted: generated with Claude (Anthropic); human conception, review, guidance and output approval by rojwilco.
 #pragma once
 
 #include "Arduino.h"

--- a/tests/mocks/Preferences.h
+++ b/tests/mocks/Preferences.h
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (c) 2026 rojwilco
+// AI-assisted: generated with Claude (Anthropic); human conception, review, guidance and output approval by rojwilco.
 #pragma once
 
 #include "Arduino.h"

--- a/tests/mocks/Update.h
+++ b/tests/mocks/Update.h
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (c) 2026 rojwilco
+// AI-assisted: generated with Claude (Anthropic); human conception, review, guidance and output approval by rojwilco.
 #pragma once
 #include "Arduino.h"
 #include <cstddef>

--- a/tests/mocks/WebServer.h
+++ b/tests/mocks/WebServer.h
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (c) 2026 rojwilco
+// AI-assisted: generated with Claude (Anthropic); human conception, review, guidance and output approval by rojwilco.
 #pragma once
 
 #include "Arduino.h"

--- a/tests/mocks/WiFi.h
+++ b/tests/mocks/WiFi.h
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (c) 2026 rojwilco
+// AI-assisted: generated with Claude (Anthropic); human conception, review, guidance and output approval by rojwilco.
 #pragma once
 
 #include "Arduino.h"

--- a/tests/mocks/WiFiClientSecure.h
+++ b/tests/mocks/WiFiClientSecure.h
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (c) 2026 rojwilco
+// AI-assisted: generated with Claude (Anthropic); human conception, review, guidance and output approval by rojwilco.
 #pragma once
 
 // Stub — the real SSL handshake is irrelevant for host-side tests.

--- a/tests/mocks/mock_support.cpp
+++ b/tests/mocks/mock_support.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (c) 2026 rojwilco
+// AI-assisted: generated with Claude (Anthropic); human conception, review, guidance and output approval by rojwilco.
 // Definitions for all extern globals declared in the mock headers.
 // This file is compiled into every test executable via sketch_lib.
 

--- a/tests/sketch_api.h
+++ b/tests/sketch_api.h
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 // Copyright (c) 2026 rojwilco
+// AI-assisted: generated with Claude (Anthropic); human conception, review, guidance and output approval by rojwilco.
 // sketch_api.h — declarations for all sketch symbols that tests depend on.
 //
 // Test files include this header instead of re-including the .ino.

--- a/tests/sketch_wrapper.cpp
+++ b/tests/sketch_wrapper.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 // Copyright (c) 2026 rojwilco
+// AI-assisted: generated with Claude (Anthropic); human conception, review, guidance and output approval by rojwilco.
 // sketch_wrapper.cpp — compiles esp32-weather-leds.ino under the host test harness.
 //
 // Include order matters:

--- a/tests/test_animation_cycles.cpp
+++ b/tests/test_animation_cycles.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (c) 2026 rojwilco
+// AI-assisted: generated with Claude (Anthropic); human conception, review, guidance and output approval by rojwilco.
 #include <gtest/gtest.h>
 #include <vector>
 #include "sketch_api.h"

--- a/tests/test_animations.cpp
+++ b/tests/test_animations.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (c) 2026 rojwilco
+// AI-assisted: generated with Claude (Anthropic); human conception, review, guidance and output approval by rojwilco.
 #include <gtest/gtest.h>
 #include "sketch_api.h"
 

--- a/tests/test_fetch_forecast.cpp
+++ b/tests/test_fetch_forecast.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (c) 2026 rojwilco
+// AI-assisted: generated with Claude (Anthropic); human conception, review, guidance and output approval by rojwilco.
 #include <gtest/gtest.h>
 #include "sketch_api.h"
 

--- a/tests/test_handle_ota.cpp
+++ b/tests/test_handle_ota.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (c) 2026 rojwilco
+// AI-assisted: generated with Claude (Anthropic); human conception, review, guidance and output approval by rojwilco.
 #include "sketch_api.h"
 #include <gtest/gtest.h>
 #include <string>

--- a/tests/test_handle_root.cpp
+++ b/tests/test_handle_root.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (c) 2026 rojwilco
+// AI-assisted: generated with Claude (Anthropic); human conception, review, guidance and output approval by rojwilco.
 #include "sketch_api.h"
 #include <gtest/gtest.h>
 #include <string>

--- a/tests/test_handle_save.cpp
+++ b/tests/test_handle_save.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (c) 2026 rojwilco
+// AI-assisted: generated with Claude (Anthropic); human conception, review, guidance and output approval by rojwilco.
 #include "sketch_api.h"
 #include <gtest/gtest.h>
 #include <string>

--- a/tests/test_handle_scan.cpp
+++ b/tests/test_handle_scan.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (c) 2026 rojwilco
+// AI-assisted: generated with Claude (Anthropic); human conception, review, guidance and output approval by rojwilco.
 #include "sketch_api.h"
 #include <gtest/gtest.h>
 #include <string>

--- a/tests/test_hostname.cpp
+++ b/tests/test_hostname.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (c) 2026 rojwilco
+// AI-assisted: generated with Claude (Anthropic); human conception, review, guidance and output approval by rojwilco.
 #include <gtest/gtest.h>
 #include "sketch_api.h"
 

--- a/tests/test_poll_weather.cpp
+++ b/tests/test_poll_weather.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (c) 2026 rojwilco
+// AI-assisted: generated with Claude (Anthropic); human conception, review, guidance and output approval by rojwilco.
 #include <gtest/gtest.h>
 #include "sketch_api.h"
 

--- a/tests/test_temp_to_color.cpp
+++ b/tests/test_temp_to_color.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (c) 2026 rojwilco
+// AI-assisted: generated with Claude (Anthropic); human conception, review, guidance and output approval by rojwilco.
 #include <gtest/gtest.h>
 #include "sketch_api.h"
 

--- a/version.h
+++ b/version.h
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 // Copyright (c) 2026 rojwilco
+// AI-assisted: generated with Claude (Anthropic); human conception, review, guidance and output approval by rojwilco.
 #pragma once
 #include <stdint.h>
 


### PR DESCRIPTION
All source, test, and mock files now carry the three-line header:
  SPDX-License-Identifier: GPL-3.0-only
  Copyright (c) 2026 rojwilco
  AI-assisted: generated with Claude (Anthropic); human conception,
  review, guidance and output approval by rojwilco.

The LICENSE file copyright notice is updated to match. Files that were
missing headers entirely (test and mock files) now have them added.

https://claude.ai/code/session_01HzgVUpUUALL3XmF43VySPc