### PR TITLE
docs: move AI attribution from LICENSE to ATTRIBUTION.md

### DIFF
--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -1,0 +1,32 @@
+# Attribution
+
+## Why this document exists
+
+The `LICENSE` file contains the unmodified GNU General Public License v3 text,
+as required for GitHub to recognize the license and for the terms to be legally
+unambiguous. Project-specific attribution that would otherwise clutter that file
+lives here instead.
+
+## Authorship and AI assistance
+
+This project was developed by **rojwilco** with the assistance of
+**Claude** (an AI assistant made by [Anthropic](https://www.anthropic.com)).
+
+| Role | Who |
+|---|---|
+| Conception and design | rojwilco |
+| Requirements and architecture | rojwilco |
+| Initial code generation | Claude (Anthropic) |
+| Review and approval of all contributions | rojwilco |
+| Integration, testing, and modification | rojwilco |
+| Ongoing maintenance | rojwilco |
+
+All code in this repository — whether written directly by rojwilco or generated
+with Claude's assistance — was conceived, directed, reviewed, and approved by
+rojwilco before inclusion. AI-generated output was used as a productive tool
+under human supervision, not as an autonomous contributor.
+
+## License
+
+This project is licensed under the **GNU General Public License v3.0**.
+See the [LICENSE](LICENSE) file for the full terms.

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,4 @@
 Copyright (c) 2026 rojwilco
-AI-assisted: generated with Claude (Anthropic); human conception, review, guidance and output approval by rojwilco.
 
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007


### PR DESCRIPTION
The AI-assisted note was embedded in the LICENSE file, which prevented
GitHub from recognising the file as standard GPLv3. Moving it to a
dedicated ATTRIBUTION.md keeps the license text clean and unambiguous
while still documenting the human-oversight / AI-generation workflow.

https://claude.ai/code/session_014dfQb7L5NmMvZ47t47UPHQ