### PR TITLE
chore: upgrade dorny/test-reporter to v3 (Node.js 24)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
         run: ctest --test-dir tests/build --output-on-failure
 
       - name: Report test results
-        uses: dorny/test-reporter@v2
+        uses: dorny/test-reporter@v3
         if: ${{ !cancelled() }}
         with:
           name: GoogleTest results


### PR DESCRIPTION
Node.js 20 was deprecated on GitHub Actions runners on June 2, 2026.
dorny/test-reporter@v3 ships with Node.js 24 support, eliminating the
remaining deprecation warning in the Unit Tests workflow.

Closes #33

https://claude.ai/code/session_013WTRVY7e226kP6vHynpqzv