### PR TITLE
fix: handle null temperature elements from Open-Meteo API

### DIFF
--- a/esp32-weather-leds.ino
+++ b/esp32-weather-leds.ino
@@ -83,6 +83,7 @@ struct DayForecast {
   float tempMin;
   float tempAvg;
   float precipProb;  // 0–100
+  bool  valid = true;
 };
 
 enum AlertType { ALERT_NONE, ALERT_HEAT, ALERT_FREEZE, ALERT_RAIN };
@@ -215,10 +216,17 @@ bool fetchForecast(DayForecast* outDays) {
   }
 
   for (int i = 0; i < cfg_num_leds; i++) {
-    outDays[i].tempMax    = maxArr[i].as<float>();
-    outDays[i].tempMin    = minArr[i].as<float>();
-    outDays[i].tempAvg    = (outDays[i].tempMax + outDays[i].tempMin) / 2.0f;
-    outDays[i].precipProb = precipArr.isNull() ? 0.0f : precipArr[i].as<float>();
+    if (maxArr[i].isNull() || minArr[i].isNull()) {
+      Serial.printf("  day %d: null temperature from API, LED disabled\n", i);
+      outDays[i].valid = false;
+      continue;
+    }
+    outDays[i].valid     = true;
+    outDays[i].tempMax   = maxArr[i].as<float>();
+    outDays[i].tempMin   = minArr[i].as<float>();
+    outDays[i].tempAvg   = (outDays[i].tempMax + outDays[i].tempMin) / 2.0f;
+    outDays[i].precipProb = (precipArr.isNull() || precipArr[i].isNull())
+                              ? 0.0f : precipArr[i].as<float>();
     Serial.printf("  day %d: max=%.1f  min=%.1f  avg=%.1f  precip=%.0f%%\n",
                   i, outDays[i].tempMax, outDays[i].tempMin,
                   outDays[i].tempAvg, outDays[i].precipProb);
@@ -231,6 +239,11 @@ bool fetchForecast(DayForecast* outDays) {
 void applyForecast(DayForecast* forecast) {
   unsigned long now = millis();
   for (int i = 0; i < cfg_num_leds; i++) {
+    if (!forecast[i].valid) {
+      leds[i] = CRGB(10, 10, 10);
+      ledStates[i].alert = ALERT_NONE;
+      continue;
+    }
     CRGB base = tempToColor(forecast[i].tempAvg);
 
     AlertType alert;

--- a/tests/sketch_api.h
+++ b/tests/sketch_api.h
@@ -53,6 +53,7 @@ struct DayForecast {
     float tempMin;
     float tempAvg;
     float precipProb;
+    bool  valid = true;
 };
 
 enum AlertType { ALERT_NONE, ALERT_HEAT, ALERT_FREEZE, ALERT_RAIN };

--- a/tests/test_fetch_forecast.cpp
+++ b/tests/test_fetch_forecast.cpp
@@ -127,6 +127,48 @@ TEST_F(FetchForecastTest, MissingPrecipArrayDefaultsToZero) {
         EXPECT_FLOAT_EQ(days[i].precipProb, 0.0f) << "Day " << i;
 }
 
+// Description: A null element in temperature_2m_max marks that day as invalid
+// so a missing value is never silently promoted to 0°F and triggers a false
+// freeze alert; adjacent valid days are unaffected.
+TEST_F(FetchForecastTest, NullMaxElementDisablesThatDay) {
+    RecordProperty("description",
+        "A null element in temperature_2m_max marks that day as invalid so a "
+        "missing value is never silently promoted to 0F and triggers a false "
+        "freeze alert; adjacent valid days are unaffected.");
+    g_mock_http_payload = String(R"({
+      "daily": {
+        "temperature_2m_max": [85.0, null, 78.0, 65.0, 72.0, 88.0],
+        "temperature_2m_min": [70.0, 75.0, 60.0, 50.0, 55.0, 72.0],
+        "precipitation_probability_max": [10.0, 20.0, 30.0, 40.0, 50.0, 60.0]
+      }
+    })");
+    DayForecast days[DEFAULT_NUM_LEDS];
+    ASSERT_TRUE(fetchForecast(days));
+    EXPECT_FALSE(days[1].valid) << "null max element should mark day invalid";
+    EXPECT_TRUE(days[0].valid) << "adjacent day should remain valid";
+    EXPECT_TRUE(days[2].valid) << "adjacent day should remain valid";
+}
+
+// Description: A null element in temperature_2m_min marks that day as invalid
+// so a missing low temperature cannot falsely trigger a freeze alert.
+TEST_F(FetchForecastTest, NullMinElementDisablesThatDay) {
+    RecordProperty("description",
+        "A null element in temperature_2m_min marks that day as invalid so a "
+        "missing low temperature cannot falsely trigger a freeze alert.");
+    g_mock_http_payload = String(R"({
+      "daily": {
+        "temperature_2m_max": [85.0, 90.0, 78.0, 65.0, 72.0, 88.0],
+        "temperature_2m_min": [70.0, null, 60.0, 50.0, 55.0, 72.0],
+        "precipitation_probability_max": [10.0, 20.0, 30.0, 40.0, 50.0, 60.0]
+      }
+    })");
+    DayForecast days[DEFAULT_NUM_LEDS];
+    ASSERT_TRUE(fetchForecast(days));
+    EXPECT_FALSE(days[1].valid) << "null min element should mark day invalid";
+    EXPECT_TRUE(days[0].valid) << "adjacent day should remain valid";
+    EXPECT_TRUE(days[2].valid) << "adjacent day should remain valid";
+}
+
 // Description: Changing cfg_latitude/cfg_longitude to non-US coordinates does
 // not affect JSON parsing; the API response structure is location-independent.
 TEST_F(FetchForecastTest, DifferentLocationStillParses) {

--- a/tests/test_poll_weather.cpp
+++ b/tests/test_poll_weather.cpp
@@ -286,6 +286,35 @@ TEST_F(PollWeatherTest, RainAlertUsesConfiguredColor) {
     EXPECT_EQ(ledStates[0].alertColor.b, 0x77) << "rain alertColor blue";
 }
 
+// ── Null / invalid days ───────────────────────────────────────────────────────
+
+// Description: A DayForecast entry with valid=false produces a dim white LED
+// (10,10,10) with ALERT_NONE, matching the whole-fetch-fail color so it is
+// visually distinguishable from a working LED without looking like a dead LED.
+TEST_F(PollWeatherTest, NullDayShowsDimWhite) {
+    RecordProperty("description",
+        "A DayForecast entry with valid=false produces a dim white LED (10,10,10) "
+        "with ALERT_NONE, matching the whole-fetch-fail color so it is visually "
+        "distinguishable from a working LED without looking like a dead LED.");
+    DayForecast forecast[DEFAULT_NUM_LEDS];
+    for (int i = 0; i < DEFAULT_NUM_LEDS; i++) {
+        forecast[i].tempMax   = 75.0f;
+        forecast[i].tempMin   = 55.0f;
+        forecast[i].tempAvg   = 65.0f;
+        forecast[i].precipProb = 10.0f;
+        forecast[i].valid     = true;
+    }
+    forecast[2].valid = false;
+    applyForecast(forecast);
+    EXPECT_EQ(leds[2].r, 10) << "invalid day LED red";
+    EXPECT_EQ(leds[2].g, 10) << "invalid day LED green";
+    EXPECT_EQ(leds[2].b, 10) << "invalid day LED blue";
+    EXPECT_EQ(ledStates[2].alert, ALERT_NONE) << "invalid day should have no alert";
+    // Adjacent LEDs should be colored normally
+    EXPECT_EQ(ledStates[1].alert, ALERT_NONE);
+    EXPECT_EQ(ledStates[3].alert, ALERT_NONE);
+}
+
 // ── Return value ──────────────────────────────────────────────────────────────
 
 // Description: pollWeather() returns true when fetchForecast() succeeds so

--- a/version.h
+++ b/version.h
@@ -6,7 +6,7 @@
 
 #define FW_VERSION_MAJOR 1
 #define FW_VERSION_MINOR 8
-#define FW_VERSION_PATCH 0
+#define FW_VERSION_PATCH 1
 
 #define FW_VERSION_INT \
     ((uint32_t)(FW_VERSION_MAJOR) << 16 | \


### PR DESCRIPTION
Open-Meteo occasionally returns null for individual array elements in
temperature_2m_max or temperature_2m_min. ArduinoJson silently converts
null to 0.0f, which is below the freeze threshold and caused false freeze
alerts and cold-blue display for affected days.

Now checks each element for null in fetchForecast(). A null max or min
marks that day's DayForecast.valid = false. applyForecast() shows dim white
(10,10,10) for invalid days — the same color used for a whole-fetch failure
— so the LED is visually distinct from both a working LED and a dead LED.

Also extends the existing whole-array precip null guard to per-element null,
defaulting to 0% (same as the whole-array case).

Verification:
- [x] `cd tests && make` passes all 11 suites (3 new tests)
- [x] JSON with a null in temperature_2m_max[1]: LED 1 shows dim white, others unchanged
- [x] JSON with a null in temperature_2m_min[1]: same behaviour
- [x] Valid days adjacent to a null day still show correct color and alerts

Closes #53

https://claude.ai/code/session_01NF9hY1TA9aerekfMvHTYK4